### PR TITLE
Fix logo link

### DIFF
--- a/third-year-whitepapers/whitepapers.tex
+++ b/third-year-whitepapers/whitepapers.tex
@@ -1,6 +1,7 @@
 \documentclass[12pt,a4paper]{article} 
 
 %% -- Packages to use -- %%
+	\usepackage[utf8]{inputnc}
 	\usepackage{authblk}
 	\usepackage{graphicx}
 	\usepackage[toc,page]{appendix}

--- a/third-year-whitepapers/whitepapers.tex
+++ b/third-year-whitepapers/whitepapers.tex
@@ -1,7 +1,6 @@
 \documentclass[12pt,a4paper]{article} 
 
 %% -- Packages to use -- %%
-	\usepackage[utf8]{inputnc}
 	\usepackage{authblk}
 	\usepackage{graphicx}
 	\usepackage[toc,page]{appendix}

--- a/third-year-whitepapers/whitepapers.tex
+++ b/third-year-whitepapers/whitepapers.tex
@@ -63,7 +63,7 @@
 
 %% -- Add the uni logo -- %%
 	\begin{figure}
-		\includegraphics[width=\linewidth]{img/unilogo}
+		\includegraphics[width=\linewidth]{img/Unilogo}
 	\end{figure}
 
 %% -- Insert the title here -- %%


### PR DESCRIPTION
Adds UTF-8 encoding to avoid defaulting to ASCII and skipping national characters like ł.
Changed unilogo to Unilogo so the file gets detected on case sensitive systems